### PR TITLE
close unused file descriptors

### DIFF
--- a/cgiserver.c
+++ b/cgiserver.c
@@ -769,7 +769,11 @@ _use_file:
 						 * Set pipes
 						 */
 						dup2(cgi_pipe_r[0],STDIN_FILENO);
+						close(cgi_pipe_r[0]);
+						close(cgi_pipe_r[1]);
 						dup2(cgi_pipe_w[1],STDOUT_FILENO);
+						close(cgi_pipe_w[0]);
+						close(cgi_pipe_w[1]);
 						/*
 						 * This is actually cheating on my pipe.
 						 */

--- a/pages/getfile.cgi
+++ b/pages/getfile.cgi
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+cat <<!
+Content-type: text/html
+Connection: close
+
+<pre>
+!
+
+hexdump -C
+
+cat <<!
+Ok
+
+!
+

--- a/pages/index.cgi
+++ b/pages/index.cgi
@@ -1,0 +1,29 @@
+#!/usr/bin/tail +3
+tail +3 $0; exit
+Content-type: text/html
+Connection: close
+
+<html>
+<head>
+<title>upload</title>
+<style>
+input { font-size: 60pt; }
+</style>
+</head>
+<body>
+
+<form method="post" enctype="multipart/form-data" action="getfile.cgi">
+
+<p>
+<input type="file" name="filename">
+</p>
+
+<p>
+<input type=submit>
+<input type=reset>
+</p>
+
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
Without this, a cgi reading from stdin will block because it still has the
write end of the pipe open. This matters to cgi scripts using POST requests
with multipart/form-data, as the examples in pages/index.cgi and
pages/getfile.cgi (let me know if you want me to remove these two files from
the commit, they are just examples to demonstrate the problem).