### PR TITLE
Add argument parsing, configurable file root, and 404.html support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,9 @@ LDLIBS := -lpthread
 CFLAGS := -g -pedantic -std=c99
 
 all: cgiserver
+
+clean:
+	rm -f *.o cgiserver
+
+install:
+	install cgiserver /usr/bin

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This is a small CGI server written in C. It has no dependencies outside of the provided files, assuming a POSIX-compatible operating environment.
 
-By default, the server will try to run on port 80. You can supply a different port number as an argument, or edit the source to change the default port.
+By default, the server will try to run on port 80. You can supply a different port number as an argument with `-p PORT`, or edit the source to change the default port.
 
-The server will serve files out of the `pages` directory, but you can change this as well by editing the source.
+The server will serve files out of the `pages` directory by default, but you can set this using `-f FILE_ROOT`.


### PR DESCRIPTION
I have made some minor quality of life changes. Hopefully these are
useful to other people as well.

- The port can now be specified with `-p PORT`
- The file root is no longer hard coded to `pages/`, it can be set with
  `-f FILE_ROOT`
- In case of an unresolved path, `404.html` will be tried as well as
  `404.htm`. Previously only the latter was tried.